### PR TITLE
fix crash in IEDriverServer

### DIFF
--- a/cpp/iedriver/CommandHandlers/SendKeysCommandHandler.cpp
+++ b/cpp/iedriver/CommandHandlers/SendKeysCommandHandler.cpp
@@ -424,6 +424,12 @@ bool SendKeysCommandHandler::GetFileSelectionDialogCandidates(std::vector<HWND> 
       LOGHR(WARN, hr) << "Process of finding child dialogs of parent window failed";
       continue;
     }
+    
+    if (!current_dialog_candidates) {
+      LOGHR(WARN, hr) << "Found no dialogs as children of parent window (null candidates)";
+      continue;
+    }
+
     hr = current_dialog_candidates->get_Length(&window_array_length);
     if (FAILED(hr)) {
       LOGHR(WARN, hr) << "Could not get length of list of child dialogs of parent window";


### PR DESCRIPTION
it seems IUIAutomationElement can return with success despite not returning an Array 

issue: https://github.com/SeleniumHQ/selenium/issues/6976

- [ ] By placing an `X` in the preceding checkbox, I verify that I have signed the [Contributor License Agreement](https://github.com/SeleniumHQ/selenium/blob/master/CONTRIBUTING.md#step-6-sign-the-cla)
